### PR TITLE
Use a single metric for core temperatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,27 @@ DataDog plugin to report sensors metrics
 
 ## Instructions
 * Install lm-sensors
-```
+```sh
 sudo apt install lm-sensors 
 ```
 
 * Detect sensors
-```
+```sh
 sudo sensors-detect
 ```
 (Save the file at the end)
 
 * Install PySensors
-```
+```sh
 /opt/datadog-agent/embedded/bin/pip install PySensors
 ```
 * Copy over the custom check and check config file to the DataDog agent install directory   
-```
-cp custom_sensors.yaml /etc/dd-agent/conf.d/
-cp custom_sensors.py /etc/dd-agent/checks.d/
+```sh
+cp custom_sensors.yaml /etc/datadog-agent/conf.d/
+cp custom_sensors.py /etc/datadog-agent/checks.d/
 ```
 
 * Restart the Datadog agent
+```sh
+sudo systemctl restart datadog-agent
+```


### PR DESCRIPTION
Rather than metrics like "sensors.Core_0", "sensors.Core_1", etc, send "sensors.core" with tag "core:Core_0", "core:Core_1", etc.

Various updates for Agent v7

Fixes #2 